### PR TITLE
Filter out error caused by pilot trying to decode a grid proxy as a JWT

### DIFF
--- a/rsyslog.conf.template
+++ b/rsyslog.conf.template
@@ -13,6 +13,9 @@ PollingInterval="1"
 # Where to place auxiliary files
 global(workDirectory="%RSYSLOG_WORKDIR%")
 
+# Filter out error caused by pilot trying to decode a grid proxy as a JWT (note '~' at the end)
+:msg, regex, ".*Failed to decode JWT in keyfile.*/ticket/myproxy.*ignoring.*"  ~
+
 # Condor-specific logging format
 template(name="Condor_SyslogProtocol23Format" type="list")
 {


### PR DESCRIPTION
Example message:
```
02/22/22 16:24:01 (pid:123669) Failed to decode JWT in keyfile '/var/lib/condor/execute/dir_104747/glide_YxkrgI/ticket/myproxy'; ignoring.
```